### PR TITLE
Bump kalman-rs, uuid, chrono, itertools version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ repository = "https://github.com/LdDl/mot-rs"
 readme = "README.md"
 keywords = ["computer-vision", "kalman", "tracking", "filtering"]
 license = "MIT"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["Dimitrii Lopanov <sexykdi@gmail.com>"]
 exclude = ["/.github", "/ci", "/tools", "release.toml", "rustfmt.toml"]
@@ -16,7 +16,7 @@ categories = ["algorithms", "computer-vision", "mathematics", "science"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kalman-rust = "0.2.2"
-uuid = { version = "1.3.1", features = ["serde", "v4"] }
-chrono = "0.4.24"
-itertools = "0.10.5"
+kalman-rust = "0.2.3"
+uuid = { version = "1.5.0", features = ["serde", "v4"] }
+chrono = "0.4.31"
+itertools = "0.11.0"


### PR DESCRIPTION
There are newer versions of `kalman-rs`, `uuid`, `chrono` and `itertools`

This PR could be merged only after `kalman-rs` PR https://github.com/LdDl/kalman-rs/pull/1 is merged