### PR TITLE
Use edition 2024

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,8 +4,8 @@ repository = "https://github.com/LdDl/mot-rs"
 readme = "README.md"
 keywords = ["computer-vision", "kalman", "tracking", "filtering"]
 license = "MIT"
-version = "0.2.3"
-edition = "2021"
+version = "0.2.4"
+edition = "2024"
 authors = ["Dimitrii Lopanov <sexykdi@gmail.com>"]
 exclude = ["/.github", "/ci", "/tools", "release.toml", "rustfmt.toml"]
 description = "Dead simple multi object tracking in Rust"
@@ -16,7 +16,7 @@ categories = ["algorithms", "computer-vision", "mathematics", "science"]
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-kalman-rust = "0.2.4"
+kalman-rust = "0.2.5"
 uuid = { version = "1.5.0", features = ["serde", "v4"] }
 chrono = "0.4.31"
 itertools = "0.11.0"

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Add dependency to your Cargo.toml file
 
 [dependencies]
 ...
-mot-rs = "0.2.0"
+mot-rs = "0.2.4"
 ...
 ```
 

--- a/src/mot/bytetrack.rs
+++ b/src/mot/bytetrack.rs
@@ -58,6 +58,7 @@ impl ByteTracker {
     ///
     /// ```
     /// use mot_rs::mot::ByteTracker;
+    /// use mot_rs::mot::MatchingAlgorithm;
     /// let max_disappeared = 5;
     /// let min_iou = 0.3;
     /// let high_thresh = 0.5;
@@ -316,7 +317,7 @@ impl ByteTracker {
                 assignments
                     .iter()
                     .enumerate()
-                    .filter(|(_, &det_idx)| det_idx < num_detections)
+                    .filter(|&(_, det_idx)| *det_idx < num_detections)
                     .map(|(track_idx, &det_idx)| (track_idx, det_idx))
                     .collect()
             }
@@ -393,7 +394,6 @@ impl ByteTracker {
 mod tests {
     use crate::mot::{ByteTracker, MatchingAlgorithm, SimpleBlob};
     use crate::utils::Rect;
-
     #[test]
     fn test_match_objects_spread() {
         let bboxes_iterations: Vec<Vec<Rect>> = vec![


### PR DESCRIPTION
- Fixed cargo doc
- Bump to edition 2024
- Bump kalman-rust version
- update reference patterns usage